### PR TITLE
Added search path for proj.db to Context.create().

### DIFF
--- a/src/main/cpp/bindings.cpp
+++ b/src/main/cpp/bindings.cpp
@@ -786,9 +786,18 @@ JNIEXPORT jobject JNICALL Java_org_osgeo_proj_UnitOfMeasure_create
  * @param  caller  The class from which this method has been invoked.
  * @return The address of the new PJ_CONTEXT structure, or 0 in case of failure.
  */
-JNIEXPORT jlong JNICALL Java_org_osgeo_proj_Context_create(JNIEnv *env, jclass caller) {
+JNIEXPORT jlong JNICALL Java_org_osgeo_proj_Context_create(JNIEnv *env, jclass caller, jstring searchPaths) {
     static_assert(sizeof(PJ_CONTEXT*) <= sizeof(jlong), "Can not store PJ_CONTEXT* in a jlong.");
     PJ_CONTEXT *ctx = proj_context_create();
+	
+	if (searchPaths != NULL) {
+		const char *path = env->GetStringUTFChars(searchPaths, nullptr);
+		if (path) {
+			proj_context_set_search_paths(ctx, 1, &path);
+			env->ReleaseStringUTFChars(searchPaths, path);
+		}
+	}
+		
     return reinterpret_cast<jlong>(ctx);
 }
 

--- a/src/main/cpp/bindings.cpp
+++ b/src/main/cpp/bindings.cpp
@@ -789,15 +789,15 @@ JNIEXPORT jobject JNICALL Java_org_osgeo_proj_UnitOfMeasure_create
 JNIEXPORT jlong JNICALL Java_org_osgeo_proj_Context_create(JNIEnv *env, jclass caller, jstring searchPaths) {
     static_assert(sizeof(PJ_CONTEXT*) <= sizeof(jlong), "Can not store PJ_CONTEXT* in a jlong.");
     PJ_CONTEXT *ctx = proj_context_create();
-	
-	if (searchPaths != NULL) {
-		const char *path = env->GetStringUTFChars(searchPaths, nullptr);
-		if (path) {
-			proj_context_set_search_paths(ctx, 1, &path);
-			env->ReleaseStringUTFChars(searchPaths, path);
-		}
-	}
-		
+    
+    if (searchPaths != NULL) {
+        const char *path = env->GetStringUTFChars(searchPaths, nullptr);
+        if (path) {
+            proj_context_set_search_paths(ctx, 1, &path);
+            env->ReleaseStringUTFChars(searchPaths, path);
+        }
+    }
+
     return reinterpret_cast<jlong>(ctx);
 }
 

--- a/src/main/cpp/org_osgeo_proj_Context.h
+++ b/src/main/cpp/org_osgeo_proj_Context.h
@@ -12,10 +12,10 @@ extern "C" {
 /*
  * Class:     org_osgeo_proj_Context
  * Method:    create
- * Signature: ()J
+ * Signature: (Ljava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL Java_org_osgeo_proj_Context_create
-  (JNIEnv *, jclass);
+  (JNIEnv *, jclass, jstring);
 
 /*
  * Class:     org_osgeo_proj_Context

--- a/src/main/java/org/osgeo/proj/Context.java
+++ b/src/main/java/org/osgeo/proj/Context.java
@@ -94,7 +94,7 @@ final class Context extends NativeResource implements AutoCloseable {
      * @throws FactoryException if the PROJ object can not be allocated.
      */
     private Context() throws FactoryException {
-        super(create());
+        super(create(System.getProperty("proj.data")));
     }
 
     /**
@@ -103,7 +103,8 @@ final class Context extends NativeResource implements AutoCloseable {
      *
      * @return pointer to the {@code PJ_CONTEXT} allocated by PROJ, or 0 if out of memory.
      */
-    private static native long create();
+    private static native long create(final String searchPath);
+    
 
     /**
      * Gets a PROJ context, creating a new one if needed.


### PR DESCRIPTION
This is useful if you can't set environment variable PROJ_LIB.