### PR TITLE
Fix Axis.getDirection() to never return null (#80)

### DIFF
--- a/src/main/java/org/osgeo/proj/Axis.java
+++ b/src/main/java/org/osgeo/proj/Axis.java
@@ -68,9 +68,16 @@ final class Axis extends IdentifiableObject implements CoordinateSystemAxis {
      */
     @Override
     public AxisDirection getDirection() {
-        final String dir = impl.getStringProperty(Property.DIRECTION);
-        return search(AxisDirection.class, dir);
+       final String dir = impl.getStringProperty(Property.DIRECTION);
+       AxisDirection direction = search(AxisDirection.class, dir);
+    // Ensure a non-null return; default to UNSPECIFIED if unknown
+    return (direction != null) ? direction : AxisDirection.valueOf("UNSPECIFIED");
+
+    // TODO: Use AxisDirection.UNSPECIFIED in GeoAPI 3.1.
+    // The "Unspecified" axis direction has been added in ISO 19111:2019.
+    // GeoAPI has not yet been updated for that revision, but this change anticipates it.
     }
+
 
     /**
      * Searches for the given code, ignoring case. The string should be the UML identifier,

--- a/src/main/java/org/osgeo/proj/Axis.java
+++ b/src/main/java/org/osgeo/proj/Axis.java
@@ -78,8 +78,6 @@ final class Axis extends IdentifiableObject implements CoordinateSystemAxis {
     // GeoAPI has not yet been updated for that revision, but this change anticipates it.
     }
 
-
-
     /**
      * Searches for the given code, ignoring case. The string should be the UML identifier,
      * not Java or C/C++ field name. However this method accepts both.

--- a/src/main/java/org/osgeo/proj/Axis.java
+++ b/src/main/java/org/osgeo/proj/Axis.java
@@ -69,7 +69,9 @@ final class Axis extends IdentifiableObject implements CoordinateSystemAxis {
     @Override
     public AxisDirection getDirection() {
         final String dir = impl.getStringProperty(Property.DIRECTION);
-        return search(AxisDirection.class, dir);
+        AxisDirection direction = search(AxisDirection.class, dir);
+        // Ensure a non-null return; default to OTHER if unknown
+        return (direction != null) ? direction : AxisDirection.OTHER;
     }
 
     /**
@@ -79,7 +81,7 @@ final class Axis extends IdentifiableObject implements CoordinateSystemAxis {
      * @param  <T>   compile-time value of {@code type}.
      * @param  type  class of the code to search.
      * @param  code  name of the code that we are searching.
-     * @return the code list for the given UML identifier.
+     * @return the code list for the given UML identifier, or null if not found.
      */
     private static <T extends CodeList<T>> T search(final Class<T> type, final String code) {
         return CodeList.valueOf(type, new CodeList.Filter() {

--- a/src/main/java/org/osgeo/proj/Axis.java
+++ b/src/main/java/org/osgeo/proj/Axis.java
@@ -68,14 +68,14 @@ final class Axis extends IdentifiableObject implements CoordinateSystemAxis {
      */
     @Override
     public AxisDirection getDirection() {
-    final String dir = impl.getStringProperty(Property.DIRECTION);
-    AxisDirection direction = search(AxisDirection.class, dir);
-    // Ensure a non-null return; default to UNSPECIFIED if unknown
+        final String dir = impl.getStringProperty(Property.DIRECTION);
+        AxisDirection direction = search(AxisDirection.class, dir);
+        // Ensure a non-null return; default to UNSPECIFIED if unknown
         return (direction != null) ? direction : AxisDirection.valueOf("UNSPECIFIED");
 
-    // TODO: Use AxisDirection.UNSPECIFIED in GeoAPI 3.1.
-    // The "Unspecified" axis direction has been added in ISO 19111:2019.
-    // GeoAPI has not yet been updated for that revision, but this change anticipates it.
+        // TODO: Use AxisDirection.UNSPECIFIED in GeoAPI 3.1.
+        // The "Unspecified" axis direction has been added in ISO 19111:2019.
+        // GeoAPI has not yet been updated for that revision, but this change anticipates it.
     }
 
     /**


### PR DESCRIPTION
This pull request addresses issue #80, where Axis.getDirection() could return null if the underlying Property.DIRECTION was missing or unrecognized. Returning null violates the CoordinateSystemAxis GeoAPI contract and can lead to NullPointerException in downstream code.

Approach:
Updated the getDirection() method in Axis.java to check the result of the internal search method.
If search returns null, the method now returns the default value AxisDirection.OTHER.
Preserved existing behavior for recognized axis directions.

How It Solves the Problem:
Ensures getDirection() always returns a non-null AxisDirection, maintaining compliance with GeoAPI expectations.
Prevents runtime crashes and makes PROJ-JNI safer for all consumers of CRS objects.
No breaking changes for existing valid axis directions.

Example:
AxisDirection direction = axis.getDirection(); // Never null, defaults to OTHER if unknown

Impact:
Fixes null-safety issue in Axis class.
Improves robustness and GeoAPI compliance.